### PR TITLE
User can now use relative path to `keyFilename`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install gcs-upload
 **options**:
 - _limit_: limits of uploaded data in object form (similar to limits option in [multer](https://github.com/expressjs/multer#limits))
 - _gcsConfig_:
-  - keyFilename: file path for credential that you have downloaded before.
+  - keyFilename: absolute or relative file path for credential that you have downloaded before.
   - bucketName: the bucket name that will contain the uploaded file, you can create one through google cloud console.
 
 It will return an upload object that have 3 methods: (.single(), .array(), and .fields()). You can use all of them just like how you would use [multer](https://github.com/expressjs/multer#singlefieldname).

--- a/index.js
+++ b/index.js
@@ -1,12 +1,33 @@
 const multer = require('multer')
 const uploadToGcs = require('./uploadToGcs')
+const path = require('path')
 
 module.exports = ({ limits, gcsConfig }) => {
   const multerStorage = multer.memoryStorage()
   const upload = multer({ storage: multerStorage, limits })
 
+  /*
+   * https://nodejs.org/api/modules.html#modules_module_parent
+   *
+   * `module.parent.filename` will return the absolute path of
+   * a file that called this module
+   */
+  const dirCaller = path.dirname(module.parent.filename)
+
+  /* then the absolute path is resolved with relative path from user */
+  const resolvedPath = path.resolve(dirCaller, gcsConfig.keyFilename)
+
+  /* then reassign it to `gcsConfig.keyFilename` */
+  gcsConfig.keyFilename = resolvedPath
+
+  /*
+   * This patch has backwards compatibility
+   * references:
+   * https://nodejs.org/api/path.html#path_path_resolve_paths
+   */
+
   return {
-    single: (fieldname) => [
+    single: fieldname => [
       upload.single(fieldname),
       async (req, res, next) => {
         if (!req.file) return next()
@@ -16,38 +37,40 @@ module.exports = ({ limits, gcsConfig }) => {
         } catch (error) {
           next(error)
         }
-      }
+      },
     ],
 
     array: (fieldname, maxCount) => [
       upload.array(fieldname, maxCount),
       async (req, res, next) => {
         try {
-          req.body[fieldname] = await Promise.all(req.files.map(file => uploadToGcs({ file, gcsConfig })))
+          req.body[fieldname] = await Promise.all(
+            req.files.map(file => uploadToGcs({ file, gcsConfig })),
+          )
           next()
         } catch (error) {
           next(error)
         }
-      }
+      },
     ],
 
-    fields: (fields) => [
+    fields: fields => [
       upload.fields(fields),
       async (req, res, next) => {
         try {
-          const links = await Promise.all(Object.entries(req.files)
-            .map(async ([fieldname, files]) => ({
-              [fieldname]: await Promise.all(files.map(file =>
-                uploadToGcs({ file, gcsConfig })
-              ))
-            }))
+          const links = await Promise.all(
+            Object.entries(req.files).map(async ([fieldname, files]) => ({
+              [fieldname]: await Promise.all(
+                files.map(file => uploadToGcs({ file, gcsConfig })),
+              ),
+            })),
           )
           Object.assign(req.body, ...links)
           next()
         } catch (error) {
           next(error)
         }
-      }
-    ]
+      },
+    ],
   }
 }


### PR DESCRIPTION
Hello, first let me say thank you for this great module.
It lift a lot of hassle when I want to upload a file to gcs.

But I found it when I set a path to credential to `keyFilename`, I need to provide an absolute (full) path to that file.
For me, it's a bit off since I get used with relative path (like when I want to import another file).

So that's why I made this pull request.
Now `keyFilename` can receive relative or absolute path to credential file. This can be achieved by using `module.parent.filename`.
References: [module.parent](https://nodejs.org/api/modules.html#modules_module_parent)

It has backwards compatibility. So for those who already use this module, their app will not get broken.
References: [path.resolve](https://nodejs.org/api/path.html#path_path_resolve_paths)

This update has gotcha :
* If user required `gcs-upload` more than one on different file with different path (directory), `module.parent.filename` will be cached, so the value is the absolute path from the file who called it first.